### PR TITLE
Fix Permissions for CRUD Local Permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
-## 0.3.2 (unreleased)
+## 0.3.3 (unreleased)
+
+Bugfixes:
+  - Local Manager can see Local Permissions page -> [View Issue](https://github.com/aquality-automation/aquality-tracking-ui/issues/22)
+
+## 0.3.2 (2019-09-10)
 
 Features:
 

--- a/src/main/java/main/controllers/Project/ProjectUserController.java
+++ b/src/main/java/main/controllers/Project/ProjectUserController.java
@@ -22,7 +22,7 @@ public class ProjectUserController extends BaseController<ProjectUserDto> {
 
     @Override
     public ProjectUserDto create(ProjectUserDto template) throws AqualityException {
-        if(baseUser.isAdmin() || baseUser.getProjectUser(template.getProject_id()).isAdmin()){
+        if(isEditorSession(template)){
             return projectUserDao.create(template);
         }else{
             throw new AqualityPermissionsException("Account is not allowed to create Project User", baseUser);
@@ -40,7 +40,7 @@ public class ProjectUserController extends BaseController<ProjectUserDto> {
 
     @Override
     public boolean delete(ProjectUserDto template) throws AqualityException {
-        if(baseUser.isAdmin() || baseUser.getProjectUser(template.getProject_id()).isAdmin()){
+        if(isEditorSession(template)){
             return projectUserDao.delete(template);
         }else{
             throw new AqualityPermissionsException("Account is not allowed to delete Project User", baseUser);
@@ -58,5 +58,11 @@ public class ProjectUserController extends BaseController<ProjectUserDto> {
             projectUser.setUser(userController.get(projectUser.getUser()).get(0));
         }
         return projectUsers;
+    }
+
+    private boolean isEditorSession(ProjectUserDto template){
+        return baseUser.isAdmin() || baseUser.isManager()
+                || baseUser.getProjectUser(template.getProject_id()).isAdmin()
+                || baseUser.getProjectUser(template.getProject_id()).isManager();
     }
 }


### PR DESCRIPTION
# PR Details

Local Manager and Coordinator are able to CRUD Local Permissions

## Related Issue

https://github.com/aquality-automation/aquality-tracking-ui/issues/22

## How Has This Been Tested

See https://github.com/aquality-automation/aquality-tracking-ui/pull/41

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
