### PR TITLE
It is not possible to import several test run results one by one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Features:
 
 Bugfixes:
   - It should not be possible to delete Customer that assigned to the projects -> [View Issue](https://github.com/aquality-automation/aquality-tracking/issues/9)
+  - It is not possible to import several test run results one by one -> [View Issue](https://github.com/aquality-automation/aquality-tracking/issues/35)
 
 ## 0.3.3 (2019-11-16)
 

--- a/src/main/java/main/utils/FileUtils.java
+++ b/src/main/java/main/utils/FileUtils.java
@@ -55,12 +55,12 @@ public class FileUtils {
 
     public void removeFiles(List<String> filePaths){
         for (String path : filePaths){
-            boolean delete = new File(path).delete();
+            removeFile(path);
         }
     }
 
     public void removeFile(String path){
-        boolean delete = new File(path).delete();
+        new File(path).delete();
     }
 
     public String readFile(String path) throws AqualityException {
@@ -74,9 +74,8 @@ public class FileUtils {
         }
     }
 
-    public String readFile(File file) throws IOException {
-        InputStream is = new FileInputStream(file);
-        return IOUtils.toString(is, "UTF-8");
+    public String getFileFolderPath(String path) {
+        return new File(path).getParent();
     }
 
     private String getFileName(final Part part) {

--- a/src/main/java/main/view/Project/ExecuteImportServlet.java
+++ b/src/main/java/main/view/Project/ExecuteImportServlet.java
@@ -22,6 +22,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.security.InvalidParameterException;
+import java.util.Date;
 import java.util.List;
 
 @WebServlet("/import")
@@ -144,12 +145,16 @@ public class ExecuteImportServlet extends BaseServlet implements IPost {
 
     private List<String> doUpload(HttpServletRequest req, HttpServletResponse resp, Integer projectId) throws ServletException, IOException {
         FileUtils fileUtils = new FileUtils();
-        return fileUtils.doUpload(req, resp, PathUtils.createPathToBin("temp", projectId.toString()));
+        return fileUtils.doUpload(req, resp, PathUtils.createPathToBin("temp", projectId.toString(), String.valueOf(new Date().getTime())));
     }
 
     private void cleanup(List<String> filePaths){
-        FileUtils fileUtils = new FileUtils();
-        fileUtils.removeFiles(filePaths);
+        if(filePaths.size() > 0) {
+            FileUtils fileUtils = new FileUtils();
+            String fileFolderPath = fileUtils.getFileFolderPath(filePaths.get(0));
+            fileUtils.removeFiles(filePaths);
+            fileUtils.removeFile(fileFolderPath);
+        }
     }
 
     private TestNameNodeType getTestNameNodeType(HttpServletRequest req) {


### PR DESCRIPTION
# PR Details

Add temp folder for import
Remove folder after import

## Related Issue

  - It is not possible to import several test run results one by one -> [View Issue](https://github.com/aquality-automation/aquality-tracking/issues/35)

## How Has This Been Tested

Execute cuncurrent import for many files for one project

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
