### PR TITLE
Add possibility to mark import as debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.3.5 (unreleased)
 
+Features:
+  - Import: Mark import as debug  -> [View Issue](https://github.com/aquality-automation/aquality-tracking/issues/47)
+
 Bugfixes:
   - Add ALLOW_UNQUOTED_CONTROL_CHARS for mapper -> [View Issue](https://github.com/aquality-automation/aquality-tracking/issues/45)
 

--- a/src/main/java/main/model/db/imports/Importer.java
+++ b/src/main/java/main/model/db/imports/Importer.java
@@ -12,35 +12,27 @@ import java.util.Date;
 import java.util.List;
 
 public class Importer extends BaseImporter {
-    private String environment;
-    private String build_name;
-    private Integer testRunId;
     private List<String> files;
     private String type;
     private TestNameNodeType testNameNodeType;
     private String suiteName;
-    private String author;
-    private String ci_build;
+    private TestRunDto testRunTemplate;
     private boolean singleTestRun;
 
     private HandlerFactory handlerFactory = new HandlerFactory();
 
     public Importer(List<String> files, TestRunDto testRunTemplate, String pattern, String type, TestNameNodeType testNameNodeType, boolean singleTestRun, UserDto user) {
         super(testRunTemplate.getProject_id(), pattern, user);
-        this.environment = testRunTemplate.getExecution_environment();
-        this.ci_build = testRunTemplate.getCi_build();
-        this.build_name = testRunTemplate.getBuild_name();
+        this.testRunTemplate = testRunTemplate;
         this.suiteName = testRunTemplate.getTest_suite().getName();
-        this.testRunId = testRunTemplate.getId();
         this.files = files;
-        this.author = testRunTemplate.getAuthor();
         this.type = type;
         this.testNameNodeType = testNameNodeType;
         this.singleTestRun = singleTestRun;
     }
 
     public List<ImportDto> executeImport() throws AqualityException {
-        if(testRunId == null && !singleTestRun){
+        if(testRunTemplate.getId() == null && !singleTestRun){
             return parseIntoMultiple();
         }
 
@@ -85,7 +77,7 @@ public class Importer extends BaseImporter {
     private void executeResultsCreation() throws AqualityException {
         fillTestRunWithInputData();
         fillTestSuiteWithInputData();
-        this.createResults(testRunId != null);
+        this.createResults(testRunTemplate.getId() != null);
         this.testRun = new TestRunDto();
         this.testResults = new ArrayList<>();
         this.tests = new ArrayList<>();
@@ -105,11 +97,12 @@ public class Importer extends BaseImporter {
 
     private void fillTestRunWithInputData(){
         testRun.setProject_id(this.projectId);
-        testRun.setCi_build(this.ci_build);
-        if(author != null) this.testRun.setAuthor(author);
-        if(environment != null) this.testRun.setExecution_environment(environment);
-        if(build_name != null) this.testRun.setBuild_name(build_name);
-        if(testRunId != null) this.testRun.setId(testRunId);
+        testRun.setCi_build(testRunTemplate.getCi_build());
+        this.testRun.setAuthor(testRunTemplate.getAuthor());
+        this.testRun.setExecution_environment(testRunTemplate.getExecution_environment());
+        this.testRun.setBuild_name(testRunTemplate.getBuild_name());
+        this.testRun.setId(testRunTemplate.getId());
+        this.testRun.setDebug(testRunTemplate.getDebug());
     }
 
     private ImportDto finishImport() throws AqualityException {

--- a/src/main/java/main/view/Project/ExecuteImportServlet.java
+++ b/src/main/java/main/view/Project/ExecuteImportServlet.java
@@ -35,6 +35,7 @@ public class ExecuteImportServlet extends BaseServlet implements IPost {
     private String suiteName;
     private Integer testRunId;
     private Boolean addToLastTestRun;
+    private Boolean debug;
     private String environment;
     private String cilink;
     private Boolean singleTestRun;
@@ -92,6 +93,7 @@ public class ExecuteImportServlet extends BaseServlet implements IPost {
         addToLastTestRun = getBooleanQueryParameter(req, ImportParams.addToLastTestRun.name());
         environment = getStringQueryParameter(req, ImportParams.environment.name());
         cilink = getStringQueryParameter(req, ImportParams.cilink.name());
+        debug = getBooleanQueryParameter(req, ImportParams.debug.name());
         validateRequest();
     }
 
@@ -108,6 +110,7 @@ public class ExecuteImportServlet extends BaseServlet implements IPost {
         testRunTemplate.setExecution_environment(environment);
         testRunTemplate.setTest_suite(testSuiteTemplate);
         testRunTemplate.setId(getTestRunId());
+        testRunTemplate.setDebug(debug ? 1 : 0);
 
         return testRunTemplate;
     }

--- a/src/main/java/main/view/Project/ImportParams.java
+++ b/src/main/java/main/view/Project/ImportParams.java
@@ -13,5 +13,6 @@ public enum ImportParams {
     format,
     singleTestRun,
     testNameKey,
-    addToLastTestRun
+    addToLastTestRun,
+    debug
 }


### PR DESCRIPTION
# PR Details

Import: Mark import as debug

## Related Issue

  - Import: Mark import as debug  -> [View Issue](https://github.com/aquality-automation/aquality-tracking/issues/47)

## How Has This Been Tested

1. Import some file with query parameter debug=true
2. Verify that imported test run is marked as debug 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
