### PR TITLE
SELECT_TEST_STATS procedure fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.4.1 (2023-06-27)
+Bugfixes:
+- Fixed an issue with the 'SELECT_TEST_STATS' procedure referencing nonexisting column
+
 ## 1.3.0 (2021-02-26)
  - Added feature that allows to link aquality entities (tests, issues and test runs) with 3rd party systems like Jira, Xray, TestRail and etc.
  In this version only Jira and Xray support has been added.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>unifi_reporting_api</groupId>
     <artifactId>api</artifactId>
     <packaging>war</packaging>
-    <version>1.4.0</version>
+    <version>1.4.1</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/resources/db_changelog/changelog.xml
+++ b/src/main/resources/db_changelog/changelog.xml
@@ -37,4 +37,5 @@
     <include file="db.changelog-1.0.5.xml" relativeToChangelogFile="true"/>
     <include file="db.changelog-1.3.0.xml" relativeToChangelogFile="true"/>
     <include file="db.changelog-1.4.0.xml" relativeToChangelogFile="true"/>
+    <include file="db.changelog-1.4.1.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db_changelog/db.changelog-1.4.1.xml
+++ b/src/main/resources/db_changelog/db.changelog-1.4.1.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+
+
+    <changeSet id="SELECT_TEST_STATS resolution fix" author="i.kulak">
+        <sql endDelimiter="#">
+            DROP procedure IF EXISTS `SELECT_TEST_STATS`;
+
+            #
+
+            CREATE PROCEDURE `SELECT_TEST_STATS`(IN request_id VARCHAR(10) )
+            BEGIN
+            SELECT id, name, developer_id, total_runs, passed, failed, app_issue, autotest_issue, resolution_na
+            FROM
+            tests
+            LEFT JOIN
+            (SELECT
+            tr.test_id,
+            SUM(IF(final_result_id != 3, 1, 0)) AS total_runs,
+            SUM(IF(final_result_id = 1, 1, 0)) AS failed,
+            SUM(IF(final_result_id = 2, 1, 0)) AS passed,
+            SUM(IF(color = 1, 1, 0)) AS app_issue,
+            SUM(IF(color = 2, 1, 0)) AS autotest_issue,
+            SUM(IF(color = 3 AND final_result_id != 2, 1, 0)) AS resolution_na
+            FROM test_results tr
+            LEFT JOIN issues AS i on issue_id = i.id 
+            INNER JOIN result_resolution AS rr ON i.resolution_id = rr.id
+            GROUP BY test_id)
+            AS result ON tests.id = result.test_id
+            Where (request_id = ''
+            OR id IN (select test_id from suite_tests where suite_id = request_id));
+            END
+        </sql>
+        <rollback>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>
+


### PR DESCRIPTION
# PR Details

Exporting of the test runs was failing because of this procedure. Resolutions were moved to the issues table instead of being in the test_results table. 

## Related Issue

https://jira.a1qa.com/browse/RNDTESTAUTO-126

## How Has This Been Tested

Updated the db with migrations. 
Export when the issue resolution is not assigned:
![image](https://github.com/aquality-automation/aquality-tracking-api/assets/44506889/f7917ce9-5d15-4acd-af37-1a2abed35520)
Export when the issue resolution is assigned:
![image](https://github.com/aquality-automation/aquality-tracking-api/assets/44506889/baba0014-e9c3-4e32-b30f-e46272a9ddab)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
