### PR TITLE
added issues/assign endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.5.0 (2023-07-28)
+- Added `/issues/assign` endpoint, which allows to check previously created Test Runs and Test Results and assign Issues to them if there's a RegEx match
+
 ## 1.4.1 (2023-06-27)
 Bugfixes:
 - Fixed an issue with the 'SELECT_TEST_STATS' procedure referencing nonexisting column

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>unifi_reporting_api</groupId>
     <artifactId>api</artifactId>
     <packaging>war</packaging>
-    <version>1.4.1</version>
+    <version>1.5.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/main/view/Project/IssuesAssignServlet.java
+++ b/src/main/java/main/view/Project/IssuesAssignServlet.java
@@ -1,0 +1,46 @@
+package main.view.Project;
+
+import main.Session;
+import main.model.dto.project.TestResultDto;
+import main.model.dto.project.TestRunDto;
+import main.view.BaseServlet;
+import main.view.IPost;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@WebServlet("/issues/assign")
+public class IssuesAssignServlet extends BaseServlet implements IPost {
+
+    @Override
+    public void doPost(HttpServletRequest req, HttpServletResponse resp) {
+        setPostResponseHeaders(resp);
+        setEncoding(resp);
+        try {
+            Session session = createSession(req);
+            Map<String, Integer> results = new HashMap<>();
+            Integer testRunId = getIntegerQueryParameter(req, "testRunId");
+            Integer testResultId = getIntegerQueryParameter(req, "testResultId");
+            if (testRunId != null) {
+                TestRunDto testRun = new TestRunDto();
+                results = session.controllerFactory.getHandler(testRun).matchIssues(testRunId);
+            } else if (testResultId != null) {
+                TestResultDto testResult = new TestResultDto();
+                results = session.controllerFactory.getHandler(testResult).matchIssues(testResultId);
+            }
+            setJSONContentType(resp);
+            resp.getWriter().write(mapper.serialize(results));
+        } catch (Exception e) {
+            handleException(resp, e);
+        }
+    }
+
+    @Override
+    public void doOptions(HttpServletRequest req, HttpServletResponse resp) {
+        setOptionsResponseHeaders(resp);
+    }
+}

--- a/src/main/java/main/view/Project/IssuesAssignServlet.java
+++ b/src/main/java/main/view/Project/IssuesAssignServlet.java
@@ -1,6 +1,7 @@
 package main.view.Project;
 
 import main.Session;
+import main.exceptions.AqualityParametersException;
 import main.model.dto.project.TestResultDto;
 import main.model.dto.project.TestRunDto;
 import main.view.BaseServlet;
@@ -10,7 +11,6 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import java.util.HashMap;
 import java.util.Map;
 
 @WebServlet("/issues/assign")
@@ -22,15 +22,17 @@ public class IssuesAssignServlet extends BaseServlet implements IPost {
         setEncoding(resp);
         try {
             Session session = createSession(req);
-            Map<String, Integer> results = new HashMap<>();
+            Map<String, Integer> results;
             Integer testRunId = getIntegerQueryParameter(req, "testRunId");
             Integer testResultId = getIntegerQueryParameter(req, "testResultId");
-            if (testRunId != null) {
-                TestRunDto testRun = new TestRunDto();
-                results = session.controllerFactory.getHandler(testRun).matchIssues(testRunId);
-            } else if (testResultId != null) {
+            if (testResultId != null) {
                 TestResultDto testResult = new TestResultDto();
                 results = session.controllerFactory.getHandler(testResult).matchIssues(testResultId);
+            } else if (testRunId != null) {
+                TestRunDto testRun = new TestRunDto();
+                results = session.controllerFactory.getHandler(testRun).matchIssues(testRunId);
+            } else {
+                throw new AqualityParametersException("You have to specify testRunId or testResultId!");
             }
             setJSONContentType(resp);
             resp.getWriter().write(mapper.serialize(results));

--- a/src/main/webapp/doc/api-doc.yaml
+++ b/src/main/webapp/doc/api-doc.yaml
@@ -60,6 +60,8 @@ tags:
     description: 'Operations with audits'
   - name: 'integrations'
     description: 'Operations to connfigure integrations with 3rdParty systems (only Jira currently supported)'
+  - name: 'assign'
+    description: "Check a test run/test result to assign issues to it if there's a RegEx match"
 
 paths:
   /public/suite/create-or-update:
@@ -663,7 +665,7 @@ paths:
             type: strings
         - in: query
           name: suite
-          description: 'Test Suite name (required only when format = MSTest and singleTestRun = true)'
+          description: 'Test Suite name (required only when format = MSTest or Cucumber and singleTestRun = true)'
           schema:
             type: string
         - in: query
@@ -1946,6 +1948,31 @@ paths:
                   "id": 2
                 }
               ]
+
+  /issues/assign:
+    post:
+      security:
+        - BasicAuth: []
+      tags:
+        - 'assign'
+      summary: "Check a test run/test result to assign issues to it if there's a RegEx match"
+      description: "Check a test run/test result to assign issues to it if there's a RegEx match\nUser can provide either Run ID or Result ID."
+      produces:
+        - 'application/json'
+      parameters:
+      - in: query
+        name: testRunId
+        description: 'ID of the Run to look into'
+        schema:
+          type: integer
+      - in: query
+        name: testResultId
+        description: 'ID of the Result to look into'
+        schema:
+          type: integer
+      responses:
+        200:
+          description: 'Issues assigned were assigned'
 
 definitions:
   Error:


### PR DESCRIPTION
# PR Details

Added issues/assign endpoint to provide possibility to assign issues automatically to old runs and results

## Related Issue

https://jira.itransition.com/browse/RNDTESTAUTO-128

## How Has This Been Tested

I had a test run with element that was not in the state exist error
![image](https://github.com/aquality-automation/aquality-tracking-api/assets/44506889/530ff77e-dc07-44e9-a602-0eaccd29bf20)
I've added an issue with regex
![image](https://github.com/aquality-automation/aquality-tracking-api/assets/44506889/bda1de21-3dc1-42a6-a2c2-d577bb876676)
I've sent a request to endpoint
![image](https://github.com/aquality-automation/aquality-tracking-api/assets/44506889/ed1f1958-e7f0-4203-9dc8-aec1ca033d95)
The issues were assigned:
![image](https://github.com/aquality-automation/aquality-tracking-api/assets/44506889/fd3f0a4b-91db-4e25-9300-05e50510cfeb)
Same was done for the testrun with javascript error in it:
![image](https://github.com/aquality-automation/aquality-tracking-api/assets/44506889/6e5e3136-bcb3-45d6-911d-5ffbd44a8132)
![image](https://github.com/aquality-automation/aquality-tracking-api/assets/44506889/c21cdad5-62fa-4323-af96-f788ad7b5412)
![image](https://github.com/aquality-automation/aquality-tracking-api/assets/44506889/4b362082-fdd3-4140-8c13-2d04e635a9ba)
![image](https://github.com/aquality-automation/aquality-tracking-api/assets/44506889/86e5fc93-3c0e-4cbb-af2f-3361656433fc)

I've also added an error handling if there's nothing to assign to (no failed results) or the IDs are wrong:
![image](https://github.com/aquality-automation/aquality-tracking-api/assets/44506889/46d6cdfb-469e-4cfc-a677-36cdaa213f95)

And Updated Swagger:
![image](https://github.com/aquality-automation/aquality-tracking-api/assets/44506889/4257fa59-d9ae-4272-8edc-d16c5626c3e2)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
