### PR TITLE
Fix 500 code for authentication issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.5.1 (2023-11-15)
+Bugfixes:
+- Fixed an issue Invalid authorisation returns 500 status code 
+
 ## 1.5.0 (2023-07-28)
 - Added `/issues/assign` endpoint, which allows to check previously created Test Runs and Test Results and assign Issues to them if there's a RegEx match
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>unifi_reporting_api</groupId>
     <artifactId>api</artifactId>
     <packaging>war</packaging>
-    <version>1.5.0</version>
+    <version>1.5.1</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.24</version>
+            <version>1.18.30</version>
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>

--- a/src/main/java/main/controllers/Administration/UserController.java
+++ b/src/main/java/main/controllers/Administration/UserController.java
@@ -2,6 +2,7 @@ package main.controllers.Administration;
 
 import com.mysql.cj.conf.ConnectionUrlParser;
 import main.controllers.BaseController;
+import main.exceptions.AqualityAuthenticationException;
 import main.exceptions.AqualityException;
 import main.exceptions.AqualityPermissionsException;
 import main.model.db.dao.project.PasswordDao;
@@ -147,7 +148,7 @@ public class UserController extends BaseController<UserDto> {
             }
         }
 
-        throw new AqualityException("Credentials you've provided are not valid. Reenter please.");
+        throw new AqualityAuthenticationException("Credentials you've provided are not valid. Reenter please.");
     }
 
     private UserDto handleLDAPAuthorization(String userName, String password) throws AqualityException {

--- a/src/main/java/main/exceptions/AqualityAuthenticationException.java
+++ b/src/main/java/main/exceptions/AqualityAuthenticationException.java
@@ -1,6 +1,6 @@
 package main.exceptions;
 
-public class AqualityAuthenticationException extends  AqualityException {
+public class AqualityAuthenticationException extends AqualityException {
     public AqualityAuthenticationException(String error)  {
         super(error);
         this.responseCode = 401;

--- a/src/main/java/main/exceptions/AqualityAuthenticationException.java
+++ b/src/main/java/main/exceptions/AqualityAuthenticationException.java
@@ -1,0 +1,8 @@
+package main.exceptions;
+
+public class AqualityAuthenticationException extends  AqualityException {
+    public AqualityAuthenticationException(String error)  {
+        super(error);
+        this.responseCode = 401;
+    }
+}

--- a/src/main/java/main/view/BaseServlet.java
+++ b/src/main/java/main/view/BaseServlet.java
@@ -218,6 +218,7 @@ public class BaseServlet extends HttpServlet {
                 case "InvalidFormatException":
                 case "AqualityQueryParameterException":
                 case "AqualitySQLException":
+                case "AqualityAuthenticationException":
                     AqualityException exception = (AqualityException) e;
                     resp.setStatus(exception.getResponseCode());
                     setResponseBody(resp, new ErrorDto(exception.getMessage()));


### PR DESCRIPTION
# PR Details

- There was created AqualityAuthenticationException class with 401 status code
- There was changing lombok from 1.18.24 to  1.18.30

## Related Issue
https://github.com/aquality-automation/aquality-tracking/issues/141

## How Has This Been Tested
Local tests pass.
![image](https://github.com/aquality-automation/aquality-tracking-api/assets/15047073/b656d112-ca1b-4bfa-9c9a-099cab0b9cd5)

Test caces:
1. user doesn't exists - 401 - ok
![image](https://github.com/aquality-automation/aquality-tracking-api/assets/15047073/df872bf7-2e21-4ca4-81a4-72ebc2c7b6f9)
2. user exists, password incorrect - 401 - ok
![image](https://github.com/aquality-automation/aquality-tracking-api/assets/15047073/373371ac-f111-440a-8d49-08492379d931)
3. user exists, password correct - authorization success - ok
![image](https://github.com/aquality-automation/aquality-tracking-api/assets/15047073/f74ca9c9-3e8e-416f-8cfa-5d38215ceff2)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
