### PR TITLE
added support of "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSX" date for NUnitV3Han…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.5.2 (2025-02-20)
+Added support for NUnit v3 results xml date "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSX" format
+
 ## 1.5.1 (2023-11-15)
 Bugfixes:
 - Fixed an issue Invalid authorisation returns 500 status code 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,42 +1,44 @@
 # CHANGELOG
+
+## 1.5.4 (2025-02-20)
+Features:
+  - Added support for NUnit v3 results xml date "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSX" format
+
 ## 1.5.3 (2024-08-11)
 Bugfixes:
-- Improved performance of internal api endpoints: /testresult, /test
+  - Improved performance of internal api endpoints: /testresult, /test
 
 ## 1.5.2 (2024-04-12)
 Bugfixes:
-- Fixed 500 (Entity is locked) issue
-- Fixed SQL connections leak
-- Improved /public/test/create-or-update, /public/test/result/start, /public/test/result/finish performance
-- Fixed INSERT_TEST_RESULT final_result_id comparison
-
-## 1.5.2 (2025-02-20)
-Added support for NUnit v3 results xml date "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSX" format
+  - Fixed 500 (Entity is locked) issue
+  - Fixed SQL connections leak
+  - Improved /public/test/create-or-update, /public/test/result/start, /public/test/result/finish performance
+  - Fixed INSERT_TEST_RESULT final_result_id comparison
 
 ## 1.5.1 (2023-11-15)
 Bugfixes:
-- Fixed an issue Invalid authorisation returns 500 status code
+  - Fixed an issue Invalid authorisation returns 500 status code
 
 ## 1.5.0 (2023-07-28)
-- Added `/issues/assign` endpoint, which allows to check previously created Test Runs and Test Results and assign Issues to them if there's a RegEx match
+  - Added `/issues/assign` endpoint, which allows to check previously created Test Runs and Test Results and assign Issues to them if there's a RegEx match
 
 ## 1.4.1 (2023-06-27)
 Bugfixes:
-- Fixed an issue with the 'SELECT_TEST_STATS' procedure referencing nonexisting column
+  - Fixed an issue with the 'SELECT_TEST_STATS' procedure referencing nonexisting column
 
 ## 1.3.0 (2021-02-26)
- - Added feature that allows to link aquality entities (tests, issues and test runs) with 3rd party systems like Jira, Xray, TestRail and etc.
+  - Added feature that allows to link aquality entities (tests, issues and test runs) with 3rd party systems like Jira, Xray, TestRail and etc.
  In this version only Jira and Xray support has been added.
- - Improved and generified work with controllers
+  - Improved and generified work with controllers
 
 ## 1.1.1 (2020-12-15)
 Bugfixes:
-- Added handling of non utf-8 body in the request
+  - Added handling of non utf-8 body in the request
 
 ## 1.1.0 (2020-12-02)
 Features:
-- Added option to enable/disable 'STARTTLS' in the email settings
-- Refactored email utilities class
+  - Added option to enable/disable 'STARTTLS' in the email settings
+  - Refactored email utilities class
 
 ## 1.0.4 (2020-11-02)
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>unifi_reporting_api</groupId>
     <artifactId>api</artifactId>
     <packaging>war</packaging>
-    <version>1.5.3</version>
+    <version>1.5.4</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/main/constants/DateFormats.java
+++ b/src/main/java/main/constants/DateFormats.java
@@ -1,0 +1,18 @@
+package main.constants;
+
+public class DateFormats {
+    public static final String ISO_DATETIME_WITH_TIMEZONE = "yyyy-MM-dd'T'HH:mm:ssX";
+    public static final String ISO_DATETIME_WITH_NANOS = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSX";
+    public static final String DATETIME_WITH_TIMEZONE = "yyyy-MM-dd HH:mm:ssX";
+    public static final String COMPACT_12H_DATETIME = "yyyyMMdd hh:mm:ss.SSS";
+    public static final String SIMPLE_DATETIME = "yyyy-MM-dd HH:mm:ss";
+    public static final String COMPACT_DATE = "yyyyMMdd";
+    public static final String SLASHED_DATE = "yyyy/MM/dd";
+    public static final String DATE_WITH_MONTH_NAME = "MMMM d, yyyy";
+    public static final String DOT_SEPARATED_DATE = "MM.dd.yyyy";
+
+    private DateFormats() {
+    }
+}
+
+

--- a/src/main/java/main/controllers/AuditController.java
+++ b/src/main/java/main/controllers/AuditController.java
@@ -1,6 +1,7 @@
 package main.controllers;
 
 import com.mysql.cj.conf.ConnectionUrlParser.Pair;
+import main.constants.DateFormats;
 import main.exceptions.AqualityException;
 import main.exceptions.AqualityPermissionsException;
 import main.exceptions.AqualityUserException;
@@ -30,7 +31,7 @@ public class AuditController extends BaseController<AuditDto> {
     private final AuditAttachmentsDao auditAttachmentsDao;
     private final AuditStatisticDao auditStatisticDao;
     private final UserDao userDao;
-    private final SimpleDateFormat formatter = new SimpleDateFormat("MM.dd.yyyy");
+    private final SimpleDateFormat formatter = new SimpleDateFormat(DateFormats.DOT_SEPARATED_DATE);
 
     public AuditController(UserDto user) {
         super(user);

--- a/src/main/java/main/model/db/imports/SAXHandlers/NUnitV2Handler.java
+++ b/src/main/java/main/model/db/imports/SAXHandlers/NUnitV2Handler.java
@@ -1,5 +1,6 @@
 package main.model.db.imports.SAXHandlers;
 
+import main.constants.DateFormats;
 import main.model.db.imports.ResultStatus;
 import main.exceptions.AqualityException;
 import main.model.db.imports.Handler;
@@ -127,7 +128,7 @@ public class NUnitV2Handler extends Handler {
     private Date convertToDate(String dateString, String timeString) throws ParseException {
         String date;
         date = String.format("%1$s %2$s", dateString, timeString);
-        DateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        DateFormat format = new SimpleDateFormat(DateFormats.SIMPLE_DATETIME);
         format.setTimeZone(TimeZone.getTimeZone("UTC"));
         return format.parse(date);
     }

--- a/src/main/java/main/model/db/imports/SAXHandlers/NUnitV3Handler.java
+++ b/src/main/java/main/model/db/imports/SAXHandlers/NUnitV3Handler.java
@@ -1,5 +1,6 @@
 package main.model.db.imports.SAXHandlers;
 
+import main.constants.DateFormats;
 import main.model.db.imports.ResultStatus;
 import main.exceptions.AqualityException;
 import main.model.db.imports.Handler;
@@ -8,12 +9,11 @@ import main.model.dto.project.TestDto;
 import main.model.dto.project.TestResultDto;
 import main.model.dto.project.TestRunDto;
 import main.model.dto.project.TestSuiteDto;
+import org.apache.commons.lang3.time.DateUtils;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 
-import java.text.DateFormat;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.*;
 
 import static main.model.db.imports.ResultStatus.*;
@@ -186,9 +186,12 @@ public class NUnitV3Handler extends Handler {
     }
 
     private Date convertToDate(String dateString) throws ParseException {
-        DateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-        format.setTimeZone(TimeZone.getTimeZone("UTC"));
-        return format.parse(dateString);
+        String[] supportedFormats = new String[]{
+                DateFormats.DATETIME_WITH_TIMEZONE,
+                DateFormats.ISO_DATETIME_WITH_NANOS
+        };
+
+        return DateUtils.parseDate(dateString, supportedFormats);
     }
 
     private ResultStatus getStatus(String status){

--- a/src/main/java/main/model/db/imports/SAXHandlers/RobotHandler.java
+++ b/src/main/java/main/model/db/imports/SAXHandlers/RobotHandler.java
@@ -1,6 +1,6 @@
 package main.model.db.imports.SAXHandlers;
 
-
+import main.constants.DateFormats;
 import main.exceptions.AqualityException;
 import main.model.db.imports.Handler;
 import main.model.db.imports.ResultStatus;
@@ -121,7 +121,7 @@ public class RobotHandler extends Handler {
     }
 
     private Date convertToDate(String dateString) throws ParseException {
-        DateFormat format = new SimpleDateFormat("yyyyMMdd hh:mm:ss.SSS");
+        DateFormat format = new SimpleDateFormat(DateFormats.COMPACT_12H_DATETIME);
         format.setTimeZone(TimeZone.getTimeZone("UTC"));
         return format.parse(dateString);
     }

--- a/src/main/java/main/model/db/imports/SAXHandlers/TRXHandler.java
+++ b/src/main/java/main/model/db/imports/SAXHandlers/TRXHandler.java
@@ -1,5 +1,6 @@
 package main.model.db.imports.SAXHandlers;
 
+import main.constants.DateFormats;
 import main.exceptions.AqualityException;
 import main.model.db.imports.Handler;
 import main.model.db.imports.ResultStatus;
@@ -154,7 +155,7 @@ public class TRXHandler extends Handler {
     private Date convertToDate(String dateString) throws ParseException {
         String[] parts = dateString.split("\\.");
         String t = parts[0].replace('T', ' ');
-        DateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        DateFormat format = new SimpleDateFormat(DateFormats.SIMPLE_DATETIME);
         format.setTimeZone(TimeZone.getTimeZone("UTC"));
         return format.parse(t);
     }

--- a/src/main/java/main/utils/DateUtils.java
+++ b/src/main/java/main/utils/DateUtils.java
@@ -1,5 +1,7 @@
 package main.utils;
 
+import main.constants.DateFormats;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -36,12 +38,12 @@ public class DateUtils {
     }
 
     public boolean compareByDateOnly(Date date1, Date date2) {
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd");
+        SimpleDateFormat sdf = new SimpleDateFormat(DateFormats.COMPACT_DATE);
         return !(date1 == null || date2 == null) && sdf.format(date1).equals(sdf.format(date2));
     }
 
     public Date fromIsoFormat(String isoDTstring) {
-        SimpleDateFormat isoDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX");
+        SimpleDateFormat isoDateFormat = new SimpleDateFormat(DateFormats.ISO_DATETIME_WITH_TIMEZONE);
         try {
             return isoDateFormat.parse(isoDTstring);
         } catch (ParseException e) {
@@ -51,12 +53,12 @@ public class DateUtils {
     }
 
     public String toyyyyMMdd(Date date){
-        DateFormat dateFormat = new SimpleDateFormat("yyyy/MM/dd");
+        DateFormat dateFormat = new SimpleDateFormat(DateFormats.SLASHED_DATE);
         return dateFormat.format(date);
     }
 
     public Date fromyyyyMMdd(String date){
-        SimpleDateFormat isoDateFormat = new SimpleDateFormat("yyyy/MM/dd");
+        SimpleDateFormat isoDateFormat = new SimpleDateFormat(DateFormats.SLASHED_DATE);
         try {
             return isoDateFormat.parse(date);
         } catch (ParseException e) {

--- a/src/test/java/tests/workers/imports/CucumberHandlerTest.java
+++ b/src/test/java/tests/workers/imports/CucumberHandlerTest.java
@@ -1,6 +1,7 @@
 package tests.workers.imports;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import main.constants.DateFormats;
 import main.model.db.imports.ImportHandlers.Cucumber;
 import main.model.dto.*;
 import main.model.dto.project.TestDto;
@@ -28,7 +29,7 @@ public class CucumberHandlerTest {
     public void tryParse(){
         try {
             String string = "January 2, 2010";
-            DateFormat format = new SimpleDateFormat("MMMM d, yyyy", Locale.ENGLISH);
+            DateFormat format = new SimpleDateFormat(DateFormats.DATE_WITH_MONTH_NAME, Locale.ENGLISH);
             format.setTimeZone(TimeZone.getTimeZone("UTC"));
             cucumber = new Cucumber(FileUtils.getResourceFile("reports/cucumber/cucumber.json"), format.parse(string));
         } catch (Exception e){

--- a/src/test/java/tests/workers/imports/IHandlerTest.java
+++ b/src/test/java/tests/workers/imports/IHandlerTest.java
@@ -1,6 +1,7 @@
 package tests.workers.imports;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import main.constants.DateFormats;
 import main.model.db.imports.Handler;
 import main.model.dto.*;
 import main.model.dto.project.TestDto;
@@ -39,7 +40,7 @@ public interface IHandlerTest {
     default Date getFinishTime() {
         try {
             String string = "January 2, 2010";
-            DateFormat format = new SimpleDateFormat("MMMM d, yyyy", Locale.ENGLISH);
+            DateFormat format = new SimpleDateFormat(DateFormats.DATE_WITH_MONTH_NAME, Locale.ENGLISH);
             format.setTimeZone(TimeZone.getTimeZone("UTC"));
             return format.parse(string);
         }catch (ParseException e){

--- a/src/test/resources/reports/Nunit3/Nunit3.xml
+++ b/src/test/resources/reports/Nunit3/Nunit3.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
-<test-run id="2" testcasecount="24" result="Failed" total="23" passed="9" failed="11" inconclusive="0" skipped="3" asserts="5" engine-version="3.10.0.0" clr-version="4.0.30319.42000" start-time="2019-06-26 09:58:55Z" end-time="2019-06-26 09:59:12Z" duration="17.129134">
+<test-run id="2" testcasecount="24" result="Failed" total="23" passed="9" failed="11" inconclusive="0" skipped="3" asserts="5" engine-version="3.10.0.0" clr-version="4.0.30319.42000" start-time="2019-06-26 09:58:55Z" end-time="2019-06-26T09:59:12.0000000Z" duration="17.129134">
   <command-line><![CDATA["C:\Program Files (x86)\NUnit.org\nunit-console\nunit3-console.exe" /out:result.xml Example.dll]]></command-line>
   <test-suite type="Assembly" id="0-1033" name="Example.dll" fullname="C:\Users\v.kostyukevich\Downloads\example-net-nunit-master\src\Example\bin\Debug\Example.dll" runstate="Runnable" testcasecount="24" result="Failed" site="Child" start-time="2019-06-26 09:58:56Z" end-time="2019-06-26 09:59:12Z" duration="16.408045" total="23" passed="9" failed="11" warnings="1" inconclusive="0" skipped="3" asserts="5">
     <environment framework-version="3.12.0.0" clr-version="4.0.30319.42000" os-version="Microsoft Windows NT 10.0.17763.0" platform="Win32NT" cwd="C:\Users\v.kostyukevich\Downloads\example-net-nunit-master\src\Example\bin\Debug" machine-name="KOSTYUKEVICHV" user="v.kostyukevich" user-domain="ITRANSITION" culture="ru-RU" uiculture="en-US" os-architecture="x64" />
@@ -34,7 +34,7 @@
             <property name="Description" value="Empty suite" />
           </properties>
         </test-suite>
-        <test-suite type="TestFixture" id="0-1000" name="Class3" fullname="Example.Tests.Class3" classname="Example.Tests.Class3" runstate="Runnable" testcasecount="3" result="Failed" label="Error" site="SetUp" start-time="2019-06-26 09:58:56Z" end-time="2019-06-26 09:58:56Z" duration="0.189286" total="3" passed="0" failed="3" warnings="0" inconclusive="0" skipped="0" asserts="0">
+        <test-suite type="TestFixture" id="0-1000" name="Class3" fullname="Example.Tests.Class3" classname="Example.Tests.Class3" runstate="Runnable" testcasecount="3" result="Failed" label="Error" site="SetUp" start-time="2019-06-26T09:58:56.0000000Z" end-time="2019-06-26T09:58:56.0000000Z" duration="0.189286" total="3" passed="0" failed="3" warnings="0" inconclusive="0" skipped="0" asserts="0">
           <properties>
             <property name="ParallelScope" value="Self" />
           </properties>
@@ -42,7 +42,7 @@
             <message><![CDATA[System.Exception : Setup exception.]]></message>
             <stack-trace><![CDATA[   at Example.Tests.Class3.OneTimeSetUp() in C:\Users\v.kostyukevich\Downloads\example-net-nunit-master\src\Example\Tests\Class3.cs:line 20]]></stack-trace>
           </failure>
-          <test-case id="0-1001" name="Test1" fullname="Example.Tests.Class3.Test1" methodname="Test1" classname="Example.Tests.Class3" runstate="Runnable" seed="305656054" result="Failed" label="Error" site="Parent" start-time="0001-01-01 00:00:00Z" end-time="0001-01-01 00:00:00Z" duration="0.000000" asserts="0">
+          <test-case id="0-1001" name="Test1" fullname="Example.Tests.Class3.Test1" methodname="Test1" classname="Example.Tests.Class3" runstate="Runnable" seed="305656054" result="Failed" label="Error" site="Parent" start-time="0001-01-01T00:00:00.0000000Z" end-time="0001-01-01T00:00:00.0000000Z" duration="0.000000" asserts="0">
             <failure>
               <message><![CDATA[OneTimeSetUp: System.Exception : Setup exception.]]></message>
             </failure>


### PR DESCRIPTION
# PR Details
Added support for NUnit v3 results xml date "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSX" format

## Related Issue
https://github.com/aquality-automation/aquality-tracking/issues/165

## How Has This Been Tested
![image](https://github.com/user-attachments/assets/d1592f5d-64ac-45fc-b314-bb0e83a94bb5)
![image](https://github.com/user-attachments/assets/ddd762b2-a8df-46b2-8107-e2e6067f5851)
![image](https://github.com/user-attachments/assets/f0211d64-7324-4a59-8e06-1293e5bc2504)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
